### PR TITLE
HULK-5 - Replace red with black

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -6,7 +6,7 @@ export const QUALITIES = [
 
 export const COLORS = {
   satisfactory: 'warning',
-  unusable: 'danger',
+  unusable: 'unusable',
   good: 'success'
 };
 

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -180,7 +180,7 @@ body {
 }
 
 .condition-unusable {
-  background-color: $brand-danger;
+  background-color: $brand-unusable;
 }
 
 .condition-satisfactory {

--- a/src/styles/_bootstrap-variables.scss
+++ b/src/styles/_bootstrap-variables.scss
@@ -10,6 +10,7 @@ $brand-success:         #72bc3d;
 $brand-info:            #05add6;
 $brand-warning:         #f5c01a;
 $brand-danger:          #f54730;
+$brand-unusable:        #222222;
 
 $body-bg:               #fff;
 $text-color:            $gray-darker;


### PR DESCRIPTION
People with red-green color blindness have hard time separating good (green) and unusable (red) units. To avoid the confusion, unusable units/routes should be marked with black color instead of red.

I had to do this change blindly, because I was unable to build this project on M1 Mac.