### PR TITLE
Clear local storage on login screen

### DIFF
--- a/src/components/LoginScreen.js
+++ b/src/components/LoginScreen.js
@@ -40,6 +40,7 @@ class LoginScreen extends React.Component {
     };
   }
   render() {
+    localStorage.clear();
     const error = this.props.authError;
     let errorMessage = null;
     if (error) {


### PR DESCRIPTION
Clear local storage on login screen to avoid displaying wrong category data.