### PR TITLE
Add page for unit observation history

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -15,6 +15,14 @@ export const fetchResource = createAction(
   }
 );
 
+export const fetchUnitObservations = createAction(
+  'GET_RESOURCE',
+  ApiClient.fetchUnitObservations,
+  (unitId) => {
+    return { resourceType: 'observation', filters: { unit: unitId } };
+  }
+);
+
 export const getNearestUnits = createAction(
   'GET_NEAREST_UNITS',
   ApiClient.getNearestUnits

--- a/src/components/ObservationItem.js
+++ b/src/components/ObservationItem.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import moment from 'moment';
+
+const SHORT_DESCRIPTIONS = {
+    ski_trail_maintenance: 'Kunnostettu',
+    ski_trail_condition: 'Kunto todettu',
+    swimming_water_temperature: 'Lämpötila todettu',
+    swimming_water_algae: 'Levätilanne todettu',
+    live_swimming_water_temperature: 'Automaattinen lämpötilamittaus'
+};
+
+function getUnitObservationText(observationName, observationProperty) {
+    if (observationProperty === 'live_swimming_water_temperature') {
+        return observationName + '°C';
+    }
+    return observationName;
+}
+
+export default function ObservationItem({ observation, className = 'unit-observation-text' }) {
+  const { id, time, property, name, value } = observation;
+  const formattedTime = moment(time).format('dd l [klo] LTS');
+
+  if (property === 'notice') {
+    return (
+      <div key={id} className={className}>
+        <small>Tekstitiedote julkaistu {formattedTime}</small><br />
+        <div className="notice-small">
+          <small>"{value?.fi}"</small>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div key={id} className={className}>
+      <small>
+        {SHORT_DESCRIPTIONS[property]}{' '}
+        <strong>
+          {getUnitObservationText(
+            name?.fi || value?.fi,
+            property
+          )}
+        </strong>{' '}
+        {formattedTime}
+      </small>
+    </div>
+  );
+}

--- a/src/components/UnitHistory.js
+++ b/src/components/UnitHistory.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+import { withRouter } from '../hooks';
+import * as actions from '../actions/index';
+import { SHORT_DESCRIPTIONS, getUnitObservationText } from './UnitStatusSummary';
+
+class UnitHistory extends React.Component {
+  componentDidMount() {
+    const { fetchUnitObservations, params } = this.props;
+    const unitId = params.unitId;
+
+    if (unitId) {
+      fetchUnitObservations(unitId);
+    }
+  }
+
+  renderObservations(observations) {
+    return observations.map(obs => {
+      const time = moment(obs.time).format('dd l [klo] LTS');
+      if (obs.property === 'notice') {
+        return (
+          <div key={obs.id} className="list-group-item unit-observation-text">
+            <small>Tekstitiedote julkaistu {time}</small><br />
+            <div className="notice-small">
+              <small>"{obs.value?.fi}"</small>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div key={obs.id} className="list-group-item unit-observation-text">
+          <small>
+            {SHORT_DESCRIPTIONS[obs.property]}{' '}
+            <strong>
+              {getUnitObservationText(
+                obs.name?.fi || obs.value?.fi,
+                obs.property
+              )}
+            </strong>{' '}
+            {time}
+          </small>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    const { unit, observations } = this.props;
+
+    if (unit === undefined) {
+      return <div>Ladataan...</div>;
+    }
+
+    return (
+      <div className="row">
+        <div className="col-xs-12">
+            <div className="list-group facility-return clearfix">
+                <Link to={`/unit/${unit.id}`} className="list-group-item">
+                    <span className="action-icon glyphicon glyphicon-chevron-left"></span>
+                    Takaisin
+                </Link>
+            </div>
+            <div className="well">
+                <h4>{ unit.name.fi }</h4>
+            </div>
+            <div className="unit-observations">
+              <h4>Historia</h4>
+              {observations && observations.length > 0 ? (
+                <div className="list-group">
+                  {this.renderObservations(observations)}
+                </div>
+              ) : (
+                <p>Ei historiatietoja</p>
+              )}
+            </div>
+        </div>
+    </div>);
+  }
+}
+
+function mapStateToProps({ data }, { params }) {
+  const unitId = Number(params.unitId);
+  const unit = data.unit[unitId];
+  const observations = data.observation
+    ? Object.values(data.observation).filter(obs => obs.unit === unitId)
+    : [];
+
+  return { unit, observations, params };
+}
+
+const mapDispatchToProps = {
+  fetchUnitObservations: actions.fetchUnitObservations
+};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(UnitHistory));

--- a/src/components/UnitHistory.js
+++ b/src/components/UnitHistory.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import { withRouter } from '../hooks';
 import * as actions from '../actions/index';
-import { SHORT_DESCRIPTIONS, getUnitObservationText } from './UnitStatusSummary';
+import ObservationItem from './ObservationItem';
 
 class UnitHistory extends React.Component {
   componentDidMount() {
@@ -18,33 +17,11 @@ class UnitHistory extends React.Component {
   }
 
   renderObservations(observations) {
-    return observations.map(obs => {
-      const time = moment(obs.time).format('dd l [klo] LTS');
-      if (obs.property === 'notice') {
-        return (
-          <div key={obs.id} className="list-group-item unit-observation-text">
-            <small>Tekstitiedote julkaistu {time}</small><br />
-            <div className="notice-small">
-              <small>"{obs.value?.fi}"</small>
-            </div>
-          </div>
-        );
-      }
-      return (
-        <div key={obs.id} className="list-group-item unit-observation-text">
-          <small>
-            {SHORT_DESCRIPTIONS[obs.property]}{' '}
-            <strong>
-              {getUnitObservationText(
-                obs.name?.fi || obs.value?.fi,
-                obs.property
-              )}
-            </strong>{' '}
-            {time}
-          </small>
-        </div>
-      );
-    });
+    return observations.map(obs => (
+      <div key={obs.id} className="list-group-item">
+        <ObservationItem observation={obs} />
+      </div>
+    ));
   }
 
   render() {

--- a/src/components/UnitStatusSummary.js
+++ b/src/components/UnitStatusSummary.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { statusBarClassName, getQualityObservation } from './utils';
 
-const SHORT_DESCRIPTIONS = {
+export const SHORT_DESCRIPTIONS = {
   ski_trail_maintenance: 'Kunnostettu',
   ski_trail_condition: 'Kunto todettu',
   swimming_water_temperature: 'Lämpötila todettu',
@@ -13,7 +13,7 @@ const SHORT_DESCRIPTIONS = {
   live_swimming_water_temperature: 'Automaattinen lämpötilamittaus'
 };
 
-function getUnitObservationText(observationName, observationProperty) {
+export function getUnitObservationText(observationName, observationProperty) {
   if (observationProperty === 'live_swimming_water_temperature') {
     return observationName + '°C';
   }
@@ -62,6 +62,7 @@ export default function UnitStatusSummary(props) {
                 <h5>
                     { observations }
                 </h5>
+                <Link to={`/unit/${props.unit.id}/history`} className="btn btn-default">Näytä historia</Link>
             </div>
         </div>
     </div>);

--- a/src/components/UnitStatusSummary.js
+++ b/src/components/UnitStatusSummary.js
@@ -1,46 +1,19 @@
 import React from 'react';
-import moment from 'moment';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
 
 import { statusBarClassName, getQualityObservation } from './utils';
+import ObservationItem from './ObservationItem';
 
-export const SHORT_DESCRIPTIONS = {
-  ski_trail_maintenance: 'Kunnostettu',
-  ski_trail_condition: 'Kunto todettu',
-  swimming_water_temperature: 'Lämpötila todettu',
-  swimming_water_algae: 'Levätilanne todettu',
-  live_swimming_water_temperature: 'Automaattinen lämpötilamittaus'
-};
 
-export function getUnitObservationText(observationName, observationProperty) {
-  if (observationProperty === 'live_swimming_water_temperature') {
-    return observationName + '°C';
-  }
-  return observationName;
-}
-
-export function Observation (props) {
-  const time = moment(props.time).format('dd l [klo] LTS');
-  if (props.property == 'notice') {
-    return (<div className="unit-observation-text">
-            <small>Tekstitiedote julkaistu { time }</small><br/>
-            <div className="notice-small"><small>"{ props.value.fi }"</small></div>
-            </div>);
-  }
-  return <div className="unit-observation-text">
-    <small>
-      { SHORT_DESCRIPTIONS[props.property] }  <strong>
-        {getUnitObservationText(props.name ? props.name.fi : props.value.fi, props.property)}
-      </strong> { time }
-    </small
-  ></div>;
+export function Observation(props) {
+  return <ObservationItem observation={props} />;
 }
 
 export default function UnitStatusSummary(props) {
   const observations = _.map(
     props.unit.observations,
-    (obs) => { return <Observation key={obs.id} {...obs} />; }
+    (obs) => <Observation key={obs.id} {...obs} />
   );
   const qualityObservation = getQualityObservation(props.unit);
   let qualityElement = null;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import DashBoard from './components/DashBoard';
 import GroupList from './components/GroupList';
 import UnitList from './components/UnitList';
 import UnitDetails from './components/UnitDetails';
+import UnitHistory from './components/UnitHistory';
 import UpdateConfirmation from './components/UpdateConfirmation';
 import DeleteConfirmation from './components/DeleteConfirmation';
 import UpdateQueue from './components/UpdateQueue';
@@ -62,6 +63,7 @@ root.render(
             <Route path="/group/:groupId/mass-edit" element={<UnitMassEditPropertySelect />} />
             <Route path="/group/:groupId/mass-edit/:propertyId" element={<UnitMassEdit />} />
             <Route path="/unit/:unitId" element={<UnitDetails />} />
+            <Route path="/unit/:unitId/history" element={<UnitHistory />} />
             <Route path="/unit/:unitId/update/:propertyId/:valueId" element={<UpdateConfirmation />} />
             <Route path="/unit/:unitId/delete/:propertyId" element={<DeleteConfirmation />} />
             <Route path="/queue" element={<UpdateQueue />} />

--- a/src/lib/municipal-services-client.js
+++ b/src/lib/municipal-services-client.js
@@ -99,6 +99,10 @@ export function fetchUnitsWithServices(services, maintenance_organization, {sele
   return fetchResource('unit', {service: serviceParameter, maintenance_organization }, selected, embedded);
 }
 
+export function fetchUnitObservations(unitId, selected, embedded) {
+  return fetchResource('observation', {unit: unitId}, selected, embedded);
+}
+
 export function postObservation(specification, token) {
   return postResource(
     'observation',


### PR DESCRIPTION
Add a page for unit observation history. The page shows all the observations for a unit.


_Button for navigation to history:_
<img width="500" alt="history_button" src="https://github.com/user-attachments/assets/6d5eb57b-1cb8-44de-b298-1211040a67f7" />


_The history page:_
<img width="500" alt="history" src="https://github.com/user-attachments/assets/99b48d63-c39c-4600-82b6-81699df6db72" />


Refs HUL-36